### PR TITLE
Associate match candidates with ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ export type MatcherOptions = {
 }
 
 export type MatchResult = {
+  id: number,
   value: string,
 
   // A number in the range (0-1]. Higher scores are more relevant.
@@ -49,9 +50,9 @@ export class Matcher {
   // Will be ordered by score, descending.
   match: (query: string, options?: MatcherOptions) => Array<MatchResult>;
 
-  addCandidates: (candidates: Array<string>) => void;
-  removeCandidates: (candidates: Array<string>) => void;
-  setCandidates: (candidates: Array<string>) => void;
+  addCandidates: (ids: Array<number>, candidates: Array<string>) => void;
+  removeCandidates: (ids: Array<number>) => void;
+  setCandidates: (ids: Array<number>, candidates: Array<string>) => void;
 }
 ```
 

--- a/lib/main.js.flow
+++ b/lib/main.js.flow
@@ -4,10 +4,6 @@ export type MatcherOptions = {
   // Default: false
   caseSensitive?: boolean,
 
-  // Prefers case-sensitive matches when the query contains an uppercase letter.
-  // Default: false
-  smartCase?: boolean,
-
   // Default: infinite
   maxResults?: number,
 
@@ -24,6 +20,7 @@ export type MatcherOptions = {
 }
 
 export type MatchResult = {
+  id: number,
   value: string,
 
   // A number in the range (0-1]. Higher scores are more relevant.
@@ -42,7 +39,7 @@ export class Matcher {
   // Will be ordered by score, descending.
   match: (query: string, options?: MatcherOptions) => Array<MatchResult>;
 
-  addCandidates: (candidates: Array<string>) => void;
-  removeCandidates: (candidates: Array<string>) => void;
-  setCandidates: (candidates: Array<string>) => void;
+  addCandidates: (ids: Array<number>, candidates: Array<string>) => void;
+  removeCandidates: (ids: Array<number>) => void;
+  setCandidates: (ids: Array<number>, candidates: Array<string>) => void;
 }

--- a/spec/fuzzy-native-spec.js
+++ b/spec/fuzzy-native-spec.js
@@ -197,11 +197,11 @@ describe('fuzzy-native', function() {
     result = matcher.match('abc');
     expect(values(result)).toEqual([]);
 
-    matcher.addCandidates(...genIds(['abc', 'def']));
+    matcher.addCandidates([0, 1], ['abc', 'def']);
     result = matcher.match('abc');
     expect(values(result)).toEqual(['abc']);
 
-    matcher.removeCandidates(['abc']);
+    matcher.removeCandidates([0]);
     result = matcher.match('');
     expect(values(result)).toEqual(['def']);
   });
@@ -235,7 +235,7 @@ describe('fuzzy-native', function() {
       longString += 'ab';
       indexes.push(i * 2, i * 2 + 1);
     }
-    matcher.addCandidates([0], [longString]);
+    matcher.setCandidates([0], [longString]);
     expect(matcher.match(longString, {recordMatchIndexes: true})).toEqual([{
       score: 1,
       id: 0,
@@ -250,7 +250,7 @@ describe('fuzzy-native', function() {
   });
 
   it('works with non-alpha characters', function() {
-    matcher.addCandidates([0, 1], ['-_01234', '01234-']);
+    matcher.setCandidates([0, 1], ['-_01234', '01234-']);
     expect(values(matcher.match('-034'))).toEqual(['-_01234']);
   });
 
@@ -258,5 +258,12 @@ describe('fuzzy-native', function() {
     const expectedMessage = 'Expected ids array and values array to have the same length';
     expect(() => matcher.addCandidates([1, 2, 3], ["a", "b"])).toThrow(expectedMessage)
     expect(() => matcher.addCandidates([1, 2], ["a", "b", "c"])).toThrow(expectedMessage)
+  });
+
+  it('returns match results for duplicate values with different ids', () => {
+    matcher.setCandidates([0, 1], ['abc', 'abc']);
+    expect(matcher.match('ac').length).toBe(2);
+    matcher.setCandidates([0, 0], ['abc', 'abc']);
+    expect(matcher.match('ac').length).toBe(1);
   })
 });

--- a/spec/fuzzy-native-spec.js
+++ b/spec/fuzzy-native-spec.js
@@ -238,6 +238,7 @@ describe('fuzzy-native', function() {
     matcher.addCandidates([0], [longString]);
     expect(matcher.match(longString, {recordMatchIndexes: true})).toEqual([{
       score: 1,
+      id: 0,
       value: longString,
       matchIndexes: indexes,
     }]);
@@ -252,4 +253,10 @@ describe('fuzzy-native', function() {
     matcher.addCandidates([0, 1], ['-_01234', '01234-']);
     expect(values(matcher.match('-034'))).toEqual(['-_01234']);
   });
+
+  it('ensures that the ids array and the values array are the same length when adding candidates', () => {
+    const expectedMessage = 'Expected ids array and values array to have the same length';
+    expect(() => matcher.addCandidates([1, 2, 3], ["a", "b"])).toThrow(expectedMessage)
+    expect(() => matcher.addCandidates([1, 2], ["a", "b", "c"])).toThrow(expectedMessage)
+  })
 });

--- a/spec/large-spec.js
+++ b/spec/large-spec.js
@@ -27,9 +27,17 @@ describe('fuzzy-native', function() {
   it('works on large inputs', () => {
     var ids = [];
     var candidates = [];
+    var usedCandidates = new Set();
     for (var i = 0; i < N; i++) {
-      ids[i] = 0;
-      candidates.push(randomString());
+      ids[i] = i;
+      while (true) {
+        var candidate = randomString();
+        if (!usedCandidates.has(candidate)) {
+          usedCandidates.add(candidate);
+          candidates.push(candidate);
+          break;
+        }
+      }
     }
     var matcher = new fuzzyNative.Matcher(ids, candidates);
 
@@ -53,20 +61,21 @@ describe('fuzzy-native', function() {
         });
         expect(results).toEqual([{
           score: 1,
-          id: 0,
+          id: idx + start,
           value: candidates[idx + start],
           matchIndexes: indexes,
         }]);
       }
 
       // 2. Delete a large chunk of strings
-      var deleted = candidates.slice(start, start + chunkSize);
-      matcher.removeCandidates(deleted);
+      var deletedIds = ids.slice(start, start + chunkSize);
+      var deletedValues = candidates.slice(start, start + chunkSize);
+      matcher.removeCandidates(deletedIds);
 
       // 3. Make sure deleted strings no longer match.
       for (var j = 0; j < 10; j++) {
-        var idx = Math.floor(Math.random() * deleted.length);
-        var results = matcher.match(deleted[idx], {
+        var idx = Math.floor(Math.random() * deletedIds.length);
+        var results = matcher.match(deletedValues[idx], {
           maxResults: 10,
           numThreads: 4,
         });

--- a/spec/large-spec.js
+++ b/spec/large-spec.js
@@ -28,7 +28,7 @@ describe('fuzzy-native', function() {
     var ids = [];
     var candidates = [];
     for (var i = 0; i < N; i++) {
-      ids[i] = i;
+      ids[i] = 0;
       candidates.push(randomString());
     }
     var matcher = new fuzzyNative.Matcher(ids, candidates);
@@ -53,6 +53,7 @@ describe('fuzzy-native', function() {
         });
         expect(results).toEqual([{
           score: 1,
+          id: 0,
           value: candidates[idx + start],
           matchIndexes: indexes,
         }]);

--- a/spec/large-spec.js
+++ b/spec/large-spec.js
@@ -25,11 +25,13 @@ function shuffle(array) {
 
 describe('fuzzy-native', function() {
   it('works on large inputs', () => {
+    var ids = [];
     var candidates = [];
     for (var i = 0; i < N; i++) {
+      ids[i] = i;
       candidates.push(randomString());
     }
-    var matcher = new fuzzyNative.Matcher(candidates);
+    var matcher = new fuzzyNative.Matcher(ids, candidates);
 
     // Match indexes should be 0..STRING_LEN - 1.
     var indexes = [];

--- a/src/MatcherBase.cpp
+++ b/src/MatcherBase.cpp
@@ -279,10 +279,10 @@ vector<MatchResult> MatcherBase::findMatches(const std::string &query,
 }
 
 void MatcherBase::addCandidate(uint32_t id, const string &candidate) {
-  auto it = lookup_.find(candidate);
+  auto it = lookup_.find(id);
   if (it == lookup_.end()) {
     string lowercase = str_to_lower(candidate);
-    lookup_[candidate] = candidates_.size();
+    lookup_[id] = candidates_.size();
     CandidateData data;
     data.id = id;
     data.value = candidate;
@@ -294,15 +294,15 @@ void MatcherBase::addCandidate(uint32_t id, const string &candidate) {
   }
 }
 
-void MatcherBase::removeCandidate(const string &candidate) {
-  auto it = lookup_.find(candidate);
+void MatcherBase::removeCandidate(uint32_t id) {
+  auto it = lookup_.find(id);
   if (it != lookup_.end()) {
     if (it->second + 1 != candidates_.size()) {
       swap(candidates_[it->second], candidates_.back());
-      lookup_[candidates_[it->second].value] = it->second;
+      lookup_[candidates_[it->second].id] = it->second;
     }
     candidates_.pop_back();
-    lookup_.erase(candidate);
+    lookup_.erase(id);
   }
 }
 

--- a/src/MatcherBase.cpp
+++ b/src/MatcherBase.cpp
@@ -275,12 +275,13 @@ vector<MatchResult> MatcherBase::findMatches(const std::string &query,
   );
 }
 
-void MatcherBase::addCandidate(const string &candidate) {
+void MatcherBase::addCandidate(uint32_t id, const string &candidate) {
   auto it = lookup_.find(candidate);
   if (it == lookup_.end()) {
     string lowercase = str_to_lower(candidate);
     lookup_[candidate] = candidates_.size();
     CandidateData data;
+    data.id = id;
     data.value = candidate;
     data.bitmask = letter_bitmask(lowercase.c_str());
     data.lowercase = move(lowercase);

--- a/src/MatcherBase.cpp
+++ b/src/MatcherBase.cpp
@@ -90,9 +90,10 @@ int score_based_root_path(const MatchOptions &options,
 void push_heap(ResultHeap &heap,
                float score,
                int score_based_root_path,
+               uint32_t id,
                const std::string *value,
                size_t max_results) {
-  MatchResult result(score, score_based_root_path, value);
+  MatchResult result(score, score_based_root_path, id, value);
   if (heap.size() < max_results || result < heap.top()) {
     heap.push(std::move(result));
     if (heap.size() > max_results) {
@@ -161,6 +162,7 @@ void thread_worker(
           result,
           score,
           score_based_root_path(options, candidate),
+          candidate.id,
           &candidate.value,
           max_results
         );
@@ -258,6 +260,7 @@ vector<MatchResult> MatcherBase::findMatches(const std::string &query,
           combined,
           top.score,
           top.score_based_root_path,
+          top.id,
           top.value,
           max_results
         );

--- a/src/MatcherBase.h
+++ b/src/MatcherBase.h
@@ -77,7 +77,7 @@ public:
   std::vector<MatchResult> findMatches(const std::string &query,
                                        const MatcherOptions &options);
   void addCandidate(uint32_t id, const std::string &candidate);
-  void removeCandidate(const std::string &candidate);
+  void removeCandidate(uint32_t id);
   void clear();
   void reserve(size_t n);
   size_t size() const;
@@ -87,6 +87,6 @@ private:
   // This makes add/remove slightly more expensive, but in our case queries
   // are significantly more frequent.
   std::vector<CandidateData> candidates_;
-  std::unordered_map<std::string, size_t> lookup_;
+  std::unordered_map<uint32_t, size_t> lookup_;
   std::string lastQuery_;
 };

--- a/src/MatcherBase.h
+++ b/src/MatcherBase.h
@@ -17,6 +17,7 @@ struct MatcherOptions {
 
 struct MatchResult {
   float score;
+  uint32_t id;
   // We can't afford to copy strings around while we're ranking them.
   // These are not guaranteed to last very long and should be copied out ASAP.
   const std::string *value;
@@ -26,8 +27,12 @@ struct MatchResult {
 
   MatchResult(float score,
               int score_based_root_path,
+              uint32_t id,
               const std::string *value)
-    : score(score), value(value), score_based_root_path(score_based_root_path) {}
+    : score(score),
+      id(id),
+      value(value),
+      score_based_root_path(score_based_root_path) {}
 
   // Order small scores to the top of any priority queue.
   // We need a min-heap to maintain the top-N results.

--- a/src/MatcherBase.h
+++ b/src/MatcherBase.h
@@ -46,6 +46,7 @@ struct MatchResult {
 class MatcherBase {
 public:
   struct CandidateData {
+    uint32_t id;
     std::string value;
     std::string lowercase;
     int num_dirs;
@@ -70,7 +71,7 @@ public:
 
   std::vector<MatchResult> findMatches(const std::string &query,
                                        const MatcherOptions &options);
-  void addCandidate(const std::string &candidate);
+  void addCandidate(uint32_t id, const std::string &candidate);
   void removeCandidate(const std::string &candidate);
   void clear();
   void reserve(size_t n);

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -108,6 +108,7 @@ public:
       options.root_path = get_string_property(options_obj, "rootPath");
     }
 
+    auto idKey = New("id").ToLocalChecked();
     auto valueKey = New("value").ToLocalChecked();
     auto scoreKey = New("score").ToLocalChecked();
     auto matchIndexesKey = New("matchIndexes").ToLocalChecked();
@@ -119,6 +120,7 @@ public:
     size_t result_count = 0;
     for (const auto &match : matches) {
       auto obj = New<v8::Object>();
+      Set(obj, idKey, New<v8::Uint32>(match.id));
       Set(obj, scoreKey, New(match.score));
       Set(obj, valueKey, New(*match.value).ToLocalChecked());
       if (match.matchIndexes != nullptr) {
@@ -141,6 +143,9 @@ public:
 
       auto ids = v8::Local<v8::Array>::Cast(info[0]);
       auto values = v8::Local<v8::Array>::Cast(info[1]);
+
+      CHECK(ids->Length() == values->Length(), "Expected ids array and values array to have the same length");
+
       // Create a random permutation so that candidates are shuffled.
       std::vector<size_t> indexes(ids->Length());
       for (size_t i = 0; i < indexes.size(); i++) {

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -168,10 +168,13 @@ public:
   static void RemoveCandidates(const FunctionCallbackInfo<v8::Value> &info) {
     auto matcher = Unwrap<Matcher>(info.This());
     if (info.Length() > 0) {
-      CHECK(info[0]->IsArray(), "Expected an array of strings");
-      auto arg1 = v8::Local<v8::Array>::Cast(info[0]);
-      for (size_t i = 0; i < arg1->Length(); i++) {
-        matcher->impl_.removeCandidate(to_std_string(arg1->Get(i)->ToString()));
+      CHECK(info[0]->IsArray(), "Expected an array of unsigned 32-bit integer ids");
+      auto ids = v8::Local<v8::Array>::Cast(info[0]);
+      for (size_t i = 0; i < ids->Length(); i++) {
+        auto id_value = ids->Get(i);
+        CHECK(id_value->IsUint32(), "Expected array to only contain unsigned 32-bit integer ids");
+        auto id = v8::Local<v8::Uint32>::Cast(id_value)->Value();
+        matcher->impl_.removeCandidate(id);
       }
     }
   }


### PR DESCRIPTION
Previously, there was no way to determine the identity of a match result other than by its textual value. In Atom's fuzzy finder, we pass relative paths from multiple project roots into this library, but mapping these relative paths back to absolute paths when processing match results required us to perform I/O to check for the existence of files.

In this PR, we allow match candidates to be associated with 32-bit unsigned integer ids. Now, when processing match results, we can look up the absolute path or any other information we care about based on this id. This PR also allows candidates with duplicate text values as long as they have different ids.

🍐'd with @rafeca on this