### PR TITLE
Remove node-pre-gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -35,17 +35,6 @@
           ],
         }],
       ],
-    },
-    {
-      'target_name': 'action_after_build',
-      'type': 'none',
-      'dependencies': [ '<(module_name)' ],
-      'copies': [
-        {
-          'files': [ '<(PRODUCT_DIR)/<(module_name).node' ],
-          'destination': '<(module_path)'
-        }
-      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "Native C++ implementation of a fuzzy string matcher.",
   "main": "lib/main.js",
   "scripts": {
-    "test": "jasmine-node --captureExceptions spec",
-    "build": "node-pre-gyp configure build",
-    "rebuild": "node-pre-gyp rebuild",
-    "install": "node-pre-gyp install --fallback-to-build"
+    "test": "jasmine-node --captureExceptions spec"
   },
   "files": [
     "binding.gyp",
@@ -25,19 +22,10 @@
   "license": "MIT",
   "dependencies": {
     "nan": "^2.0.0",
-    "node-pre-gyp": "^0.10.0",
     "semver": "^5.0.0"
   },
-  "bundledDependencies": [
-    "node-pre-gyp"
-  ],
   "devDependencies": {
     "jasmine-node": "^1.14.5",
     "rimraf": "^2.5.2"
-  },
-  "binary": {
-    "module_name": "fuzzy-native",
-    "module_path": "./build/{module_name}/v{version}/",
-    "host": "https://github.com/"
   }
 }


### PR DESCRIPTION
https://github.com/atom/fuzzy-native/commit/7c0844fd5cb3e6ccd36d3dd7cf8a8ce6c1eca191 removed pretty much all the node-pre-gyp logic, but left the node-pre-gyp dependency installed. It's rather useless; the automatic installation will always fail and fall back to node-gyp, but I was seeing some occasional gyp errors about existing paths created by (I assume) node-pre-gyp. After removing this dependency, I no longer see those errors when building Atom.