### PR TITLE
Allow _ and \ to match path separators

### DIFF
--- a/spec/fuzzy-native-spec.js
+++ b/spec/fuzzy-native-spec.js
@@ -265,5 +265,79 @@ describe('fuzzy-native', function() {
     expect(matcher.match('ac').length).toBe(2);
     matcher.setCandidates([0, 0], ['abc', 'abc']);
     expect(matcher.match('ac').length).toBe(1);
-  })
+  });
+
+  it('returns matches when using different path separators', () => {
+    expect(
+      values(matcher.match('path1_path2_path3_zzz', {caseSensitive: true}))
+    ).toEqual([
+      '/path1/path2/path3/zzz',
+    ]);
+    expect(
+      values(matcher.match('path1_path2_path3_zzz', {caseSensitive: false}))
+    ).toEqual([
+      '/path1/path2/path3/zzz',
+    ]);
+
+    expect(
+      values(matcher.match('\\path1\\path2\\path3\\zzz', {caseSensitive: true}))
+    ).toEqual([
+      '/path1/path2/path3/zzz',
+    ]);
+    expect(
+      values(matcher.match('\\path1\\path2\\path3\\zzz', {caseSensitive: false}))
+    ).toEqual([
+      '/path1/path2/path3/zzz',
+    ]);
+  });
+
+  it('returns exact matches than normalized path separator matches', () => {
+    matcher.setCandidates(
+      [0, 1, 2],
+      ['/path1/path2/path3/zzz', '/path1/path2/path3/zzz_ooo', '/path1/path2/path3/zzz/ooo']
+    );
+
+    expect(
+      values(matcher.match('path1/path2/path3/zzz', {caseSensitive: true}))
+    ).toEqual([
+      '/path1/path2/path3/zzz',
+      '/path1/path2/path3/zzz/ooo',
+      '/path1/path2/path3/zzz_ooo'
+    ]);
+    expect(
+      values(matcher.match('zzz_ooo', {caseSensitive: true}))
+    ).toEqual([
+      '/path1/path2/path3/zzz_ooo',
+      '/path1/path2/path3/zzz/ooo'
+    ]);
+    expect(
+      values(matcher.match('path1/path2/path3/zzz_ooo', {caseSensitive: true}))
+    ).toEqual([
+      '/path1/path2/path3/zzz_ooo',
+      '/path1/path2/path3/zzz/ooo'
+    ]);
+    expect(
+      values(matcher.match('path1/path2/path3/zzz_ooo', {caseSensitive: true}))
+    ).toEqual([
+      '/path1/path2/path3/zzz_ooo',
+      '/path1/path2/path3/zzz/ooo'
+    ]);
+    expect(
+      values(matcher.match('path1_path2_path3_zzz_ooo', {caseSensitive: true}))
+    ).toEqual([
+      '/path1/path2/path3/zzz_ooo',
+      '/path1/path2/path3/zzz/ooo'
+    ]);
+    expect(
+      values(matcher.match('path1/path2_path3/zzz_ooo', {caseSensitive: false}))
+    ).toEqual([
+      '/path1/path2/path3/zzz_ooo',
+      '/path1/path2/path3/zzz/ooo'
+    ]);
+    expect(
+      values(matcher.match('zzz/ooo', {caseSensitive: false}))
+    ).toEqual([
+      '/path1/path2/path3/zzz/ooo'
+    ]);
+  });
 });

--- a/src/MatcherBase.cpp
+++ b/src/MatcherBase.cpp
@@ -24,8 +24,6 @@ inline uint64_t letter_bitmask(const std::string &str) {
       result |= count_bit << (index * 2);
     } else if (c == '-') {
       result |= (1UL << 52);
-    } else if (c == '_') {
-      result |= (1UL << 53);
     } else if (c >= '0' && c <= '9') {
       result |= (1UL << (c - '0' + 54));
     }


### PR DESCRIPTION
This PR addresses the feedback from @fedexyz ([comment](https://github.com/atom/fuzzy-finder/issues/379#issuecomment-506465900)) and @SongWorks ([comment](https://github.com/atom/fuzzy-finder/issues/379#issuecomment-503549455)) around matching full paths using `_` or `\\`.

This is a common pattern in PHP, where in order to create namespaces, people either use underscores or `\\` (for real namespacing) on the class names.

Usually, these namespaces match the folder structure, so a class named `App_Controllers_MyController` or `\\App\\Controllers\\MyController` will be located in `src/App/Controllers/MyController.php`.

For convenience, before the fast mode, people used to copy the classname from the editor and paste it on the fuzzy finder, which returned the result `src/App/Controllers/MyController.php` that the user expected (even if the matching logic was not very clear).

When we implemented the fast mode, this functionality was lost, so this PR adds the relevant logic to `fuzzy-native` (the library that the fast mode uses to match paths) to add it back.

## Alternate designs

I've considered making this mode configurable, but this would add extra complexity on the logic, and since the previous fuzzyfinder matcher didn't have it configurable I thought it's not worth it to add an extra config option.