### PR TITLE
Remove static linking to libstdc++

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -30,7 +30,6 @@
         }],
         ['OS == "linux"', {
           'ldflags': [
-            '-static-libstdc++',
             '-s',
           ],
         }],


### PR DESCRIPTION
### Identify the Bug
Recent Fedora releases don't ship with the static libstdc++ library (package libstdc++-static) so builds fail with "/usr/bin/ld: cannot find -lstdc++". Unfortunately, the message doesn't tell you it's looking for the _static_ version which leads to much confusion since /usr/lib64/libstdc++.so _is_ there.

Error:
```
  CXX(target) Release/obj.target/fuzzy-native/src/score_match.o
  CXX(target) Release/obj.target/fuzzy-native/src/MatcherBase.o
  SOLINK_MODULE(target) Release/obj.target/fuzzy-native.node
/usr/bin/ld: cannot find -lstdc++
collect2: error: ld returned 1 exit status
make: *** [fuzzy-native.target.mk:141: Release/obj.target/fuzzy-native.node] Error 1
```

### Description of the Change
There doesn't seem to be any real need to use the static library so this change removes the '-static-libstdc++' ld flag from binding.gyp and allows the package to dynamically bind to libstdc++.

### Alternate Designs
Other than updating the documentation (both Atom and fuzzy-native) to include the requirement for the libstdc++-static package, I'm not sure there are any. 

### Possible Drawbacks
Can't think of any.  If libstdc++ was unstable and undergoing large changes I could see the advantage of locking to a specific version using the static library.  It's ubiquitous and super stable though and the fuzzy-native code doesn't appear to do anything out of the ordinary that might warrant the static library.

### Verification Process
Ran `npm test` before and after the change.  One test does fail both before and after.
```
19 tests, 129 assertions, 1 failure, 0 skipped
```

### Release Notes
Remove static linking to libstdc++
