### PR TITLE
Fix compilation errors on node 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom/fuzzy-native",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom/fuzzy-native",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Native C++ implementation of a fuzzy string matcher.",
   "main": "lib/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "repository": "https://github.com/atom/fuzzy-native",
   "license": "MIT",
   "dependencies": {
-    "nan": "^2.0.0"
+    "nan": "^2.14.0"
   },
   "devDependencies": {
     "jasmine-node": "^1.14.5",


### PR DESCRIPTION
The following errors were generated while trying to compile on node 12
```
../src/binding.cpp:33:37: error: too few arguments to function call, single
      argument 'isolate' was not specified
  std::string str(v8str->Utf8Length(), ' ');

../src/binding.cpp:34:27: error: too few arguments to function call, expected at
      least 2, have 1
  v8str->WriteUtf8(&str[0]);
  ~~~~~~~~~~~~~~~~        

../src/binding.cpp:54:37: error: no matching member function for call to
      'ToString'
    return to_std_string(propLocal->ToString());

../src/binding.cpp:76:47: error: too few arguments to function call, single
      argument 'context' was not specified
    MatcherConstructor.Reset(tpl->GetFunction());

../src/binding.cpp:77:73: error: too few arguments to function call, single
      argument 'context' was not specified
    exports->Set(Nan::New("Matcher").ToLocalChecked(), tpl->GetFunction());

../src/binding.cpp:95:46: error: no matching member function for call to
      'ToString'
    std::string query(to_std_string(info[0]->ToString()));

../src/binding.cpp:100:35: error: no matching member function for call to
      'ToObject'
      auto options_obj = info[1]->ToObject();

../src/binding.cpp:162:52: error: no matching member function for call to
      'ToString'
        auto value = to_std_string(values->Get(i)->ToString());