### PR TITLE
Fix rebase command in the "How to keep this fork updated" section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Next, we are going to create a `sync-upstream` branch which is going to contain 
 # Create the branch pointing to the upstream branch.
 $ git checkout -b sync-upstream upstream
 # Rebase all the new commits (descendants of the commit stored in .last-synced-commit) onto the master branch (this may lead to some conflicts).
-$ git rebase --onto master "$(cat .last-synced-commit)" sync-upstream
+$ git rebase --onto master "$(git show master:.last-synced-commit)" sync-upstream
 ```
 
 Now we have on the `sync-upstream` branch all the new commits from the upstream repo since the last time we synced. We may want to discard some of these commits (for example the ones that modify files that handle building multiple projects, since they only make sense on the upstream repo):

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Next, we are going to create a `sync-upstream` branch which is going to contain 
 # Create the branch pointing to the upstream branch.
 $ git checkout -b sync-upstream upstream
 # Rebase all the new commits (descendants of the commit stored in .last-synced-commit) onto the master branch (this may lead to some conflicts).
-$ git rebase --onto master $(cat .last-synced-commit) sync-upstream
+$ git rebase --onto master "$(cat .last-synced-commit)" sync-upstream
 ```
 
 Now we have on the `sync-upstream` branch all the new commits from the upstream repo since the last time we synced. We may want to discard some of these commits (for example the ones that modify files that handle building multiple projects, since they only make sense on the upstream repo):


### PR DESCRIPTION
### Requirements for Contributing Documentation

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.

### Description of the Change

Updates a command in the "How to keep this fork updated" section of `README.md` to work more reliably.

There are [instructions for updating this fork to sync](https://github.com/atom/fuzzy-native#how-to-keep-this-fork-updated) with https://github.com/facebook-atom/nuclide-prebuilt-libs/tree/master/fuzzy-native.

I personally tried to follow them, but this command did not work:

```console
$ git rebase --onto master $(cat .last-synced-commit) sync-upstream
cat: .last-synced-commit: No such file or directory
First, rewinding head to replay your work on top of it...
```

<details><summary>Why this doesn't work (click to expand):</summary>

For some reason the `$(cat .last-synced-commit)` part errors out, not finding the `.last-synced-commit` file. (I thought maybe it was because the file doesn't exist on the facebook-maintained branch we are rebasing, but `cat` doesn't find the file even if I manually copy it into place.) This erroring out `cat` subshell command then gets interpolated back into the rebase command as an unquoted, empty string. The causes the `git rebase` command to interpolate to simply `git rebase --onto master  sync-upstream`. This makes the intended third argument to `git rebase --onto` be read as the second argument instead, completely changing the meaning of the `rebase` command.

This results in a fast-forward of `sync-upstream` branch to meet the `HEAD` of `master`, and no actual rebase is performed.

</details>

Rather than the apparently unreliable step of reading `.last-synced-commit` from the working tree, I switched the command to read the content of `.last-synced-commit` as it is checked in on `master` branch, the branch we are trying to rebase onto:

```console
$ git rebase --onto master "$(git show master:.last-synced-commit)" sync-upstream
```

<details><summary>Sample output (click to expand):</summary>

```console
$ git rebase --onto master "$(git show master:.last-synced-commit)" sync-upstream
First, rewinding head to replay your work on top of it...
Applying: Migrate to vscode 1.39.1
Using index info to reconstruct a base tree...
M	package.json
M	src/binding.cpp
Falling back to patching base and 3-way merge...
Auto-merging src/binding.cpp
CONFLICT (content): Merge conflict in src/binding.cpp
Auto-merging package.json
CONFLICT (content): Merge conflict in package.json
error: Failed to merge in the changes.
Patch failed at 0001 Migrate to vscode 1.39.1
hint: Use 'git am --show-current-patch' to see the failed patch
Resolve all conflicts manually, mark them as resolved with
"git add/rm <conflicted_files>", then run "git rebase --continue".
You can instead skip this commit: run "git rebase --skip".
To abort and get back to the state before "git rebase", run "git rebase --abort".
```

</details>

I also used quotation marks `"` around the subshell command `$()`, so no-matter what, in the worst-case scenario `git rebase` sees this as the second argument: `""`, rather than skipping the second argument and running a totally different `git rebase` operation than what was intended.

I believe this makes the instructions in this section properly functional from beginning to end.

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
N/A